### PR TITLE
V0.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # Kea Traefik Plugin
 An Identity aware middleware for traefik using netbird as a source
 
+Feel free to contrib
+
+
 Configuration uses only two middleware arguments:
 
 - `configPath`: path to a YAML file, typically mounted as a Docker secret

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module kea-traefik-plugin
+module github.com/C4mill3/kea-traefik-plugin
 
 go 1.25.5
 


### PR DESCRIPTION
Fix Catalog bot issue: module name in `mod.go` was not matching repo url