### PR TITLE
Support for forwarded remote-user and remote-email headers

### DIFF
--- a/.traefik.yml
+++ b/.traefik.yml
@@ -17,3 +17,6 @@ testData:
         - "127.0.0.1/32"
   allowGroups:
     - "All"
+  # Optional: customize header names (defaults are Remote-User and Remote-Email)
+  userHeader: "X-Auth-User"
+  emailHeader: "X-Auth-Email"

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Kea Traefik Plugin
+
 An Identity aware middleware for traefik using netbird as a source
 
 Feel free to contrib
-
 
 Configuration uses only two middleware arguments:
 
@@ -11,6 +11,8 @@ Configuration uses only two middleware arguments:
 - `allowGroups`: NetBird groups allowed for the route
 - `appUrl`: optional URL/domain this route protects. When set, the route is recorded in a global registry so routes with `accessHeaders` enabled can advertise it.
 - `accessHeaders`: optional bool (default `false`). When `true`, this route injects the `X-Kea-Allowed-Urls` request header into the backend, listing every registered `appUrl` the caller's IP is allowed to access (comma-separated).
+- `userHeader`: optional string (default `Remote-User`). The header name to set with the user's name.
+- `emailHeader`: optional string (default `Remote-Email`). The header name to set with the user's email.
 
 If both are set, `inlineConfig` has priority over `configPath`.
 
@@ -37,7 +39,6 @@ The homepage backend then reads `X-Kea-Allowed-Urls` (a comma-separated list of
 allowed `appUrl`s) off the incoming request and renders accordingly. The header
 is always overwritten on routes with `accessHeaders=true`, so a client cannot
 spoof it.
-
 
 Example dynamic config in traefik file:
 
@@ -76,6 +77,7 @@ http:
 ```
 
 Example label config:
+
 ```yaml
 labels:
   - "traefik.http.middlewares.kea-homelab.plugin.kea.configPath=/run/secrets/kea-conf.yml"
@@ -93,7 +95,7 @@ Settings:
   LogLevel: Err # Optional: None, Err, or Info
 
 Groups: #Optional, create custom group and/or add ip to already existing netbird group
-  homelab: 
-   - "192.168.1.0/24" #Allow request from local network
-   - "172.21.0.27/32"
+  homelab:
+    - "192.168.1.0/24" #Allow request from local network
+    - "172.21.0.27/32"
 ```

--- a/kea.go
+++ b/kea.go
@@ -23,6 +23,8 @@ import (
 var (
 	globalMu        sync.RWMutex
 	globalCache     GroupPeers
+	globalIPUserMap IPUserMap
+	globalUserCache UserIDMap
 	globalGroups    groups
 	globalLastFetch time.Time
 	globalConfigRef string
@@ -46,6 +48,12 @@ type Config struct {
 	// (accessHeaderName) listing every registered AppURL the caller's IP is
 	// allowed to access. Defaults to false so other routes are unaffected.
 	AccessHeaders bool `json:"accessHeaders,omitempty"`
+	// UserHeader specifies the header name for the authenticated user's name.
+	// Defaults to "Remote-User" if not set.
+	UserHeader string `json:"userHeader,omitempty"`
+	// EmailHeader specifies the header name for the authenticated user's email.
+	// Defaults to "Remote-Email" if not set.
+	EmailHeader string `json:"emailHeader,omitempty"`
 }
 
 // inlineConfig can be used directly in plugin config when no file secret is mounted.
@@ -102,6 +110,8 @@ type NetbirdIPGuard struct {
 	name          string
 	allowGroups   []string
 	accessHeaders bool
+	userHeader    string
+	emailHeader   string
 }
 
 // New creates a new Kea middleware instance.
@@ -129,6 +139,7 @@ func New(_ context.Context, next http.Handler, cfg *Config, name string) (http.H
 		}
 		globalLogLevel = parsedLogLevel
 		globalGroups = shared.Groups
+
 		infof("initialized: config=%s url=%s refreshInterval=%s localGroups=%d logLevel=%s",
 			globalConfigRef, globalURL, globalInterval, len(globalGroups), logLevelName(globalLogLevel))
 	})
@@ -141,13 +152,24 @@ func New(_ context.Context, next http.Handler, cfg *Config, name string) (http.H
 		globalRoutesMu.Unlock()
 	}
 
-	infof("new instance: me=%s allowGroups=%v appUrl=%q accessHeaders=%t", name, cfg.AllowGroups, cfg.AppURL, cfg.AccessHeaders)
+	userHeader := "Remote-User"
+	emailHeader := "Remote-Email"
+	if cfg.UserHeader != "" {
+		userHeader = cfg.UserHeader
+	}
+	if cfg.EmailHeader != "" {
+		emailHeader = cfg.EmailHeader
+	}
+
+	infof("new instance: me=%s allowGroups=%v appUrl=%q accessHeaders=%t userHeader=%q emailHeader=%q", name, cfg.AllowGroups, cfg.AppURL, cfg.AccessHeaders, userHeader, emailHeader)
 
 	return &NetbirdIPGuard{
 		next:          next,
 		name:          name,
 		allowGroups:   cfg.AllowGroups,
 		accessHeaders: cfg.AccessHeaders,
+		userHeader:    userHeader,
+		emailHeader:   emailHeader,
 	}, nil
 }
 
@@ -165,6 +187,8 @@ func (g *NetbirdIPGuard) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	globalMu.RLock()
 	localCache := globalCache
 	localGroups := globalGroups
+	localIPUserMap := globalIPUserMap
+	localUserCache := globalUserCache
 	globalMu.RUnlock()
 
 	// Inject the access header before forwarding. We always Set (overwrite) so a
@@ -178,6 +202,7 @@ func (g *NetbirdIPGuard) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	for _, group := range g.allowGroups { // check for each group allowed on this route
 		if matched, src := ipInGroup(ip, srcIP, group, localGroups, localCache); matched {
 			infof("ALLOW ip=%s group=%s (%s) route=%s", srcIP, group, src, g.name)
+			addForwardedHeaders(req, srcIP, localIPUserMap, localUserCache, g.userHeader, g.emailHeader)
 			g.next.ServeHTTP(rw, req)
 			return
 		}
@@ -255,14 +280,24 @@ func refreshIfNeeded() error {
 	}
 
 	infof("refreshing peer cache from %s", globalURL)
-	peers, err := FetchNetbirdPeerGroups(globalURL, globalToken)
+	peers, ipUserMap, err := FetchNetbirdPeerGroups(globalURL, globalToken)
 	if err != nil {
 		errf("fetching peers failed: %v", err)
 		return err
 	}
+
+	// Fetch user information
+	users, err := FetchNetbirdUsers(globalURL, globalToken)
+	if err != nil {
+		errf("fetching users failed: %v", err)
+		return err
+	}
+
 	globalCache = peers
+	globalIPUserMap = ipUserMap
+	globalUserCache = users
 	globalLastFetch = time.Now()
-	infof("peer cache refreshed: %d groups loaded", len(peers))
+	infof("peer cache refreshed: %d groups loaded, %d users", len(peers), len(users))
 	return nil
 }
 
@@ -356,4 +391,23 @@ func extractIP(req *http.Request) string {
 		return req.RemoteAddr
 	}
 	return host
+}
+
+// addForwardedHeaders adds the forwarded headers when the IP is allowed
+func addForwardedHeaders(req *http.Request, srcIP string, localIPUserMap map[string]string, localUserCache map[string]UserInfo, userHeader string, emailHeader string) {
+	// Get user ID for this IP
+	userID, exists := localIPUserMap[srcIP]
+	if !exists {
+		return
+	}
+
+	// Get user information
+	user, userExists := localUserCache[userID]
+	if !userExists {
+		return
+	}
+
+	// Set headers with actual user information
+	req.Header.Set(userHeader, user.Name)
+	req.Header.Set(emailHeader, user.Email)
 }

--- a/kea.go
+++ b/kea.go
@@ -395,6 +395,12 @@ func extractIP(req *http.Request) string {
 
 // addForwardedHeaders adds the forwarded headers when the IP is allowed
 func addForwardedHeaders(req *http.Request, srcIP string, localIPUserMap map[string]string, localUserCache map[string]UserInfo, userHeader string, emailHeader string) {
+
+	// Remove any incoming values so they can never reach the backend unverified.
+	req.Header.Del(userHeader)
+	req.Header.Del(emailHeader)
+
+	
 	// Get user ID for this IP
 	userID, exists := localIPUserMap[srcIP]
 	if !exists {

--- a/netbird_api.go
+++ b/netbird_api.go
@@ -14,15 +14,28 @@ type peerGroup struct {
 type peer struct {
 	IP     string      `json:"ip"`
 	Groups []peerGroup `json:"groups"`
+	UserID string      `json:"user_id"`
 }
+
+// UserInfo contains information about a user
+type UserInfo struct {
+	ID    string `json:"id"`
+	Email string `json:"email"`
+	Name  string `json:"name"`
+}
+
+// UserIDMap maps user IDs to user information
+type UserIDMap map[string]UserInfo
+
+// IPUserMap maps IP addresses to user IDs
+type IPUserMap map[string]string
 
 // GroupPeers maps each group name to the list of peer IPs that belong to it.
 type GroupPeers map[string][]string
 
-// FetchNetbirdPeerGroups calls the NetBird API peers endpoint and returns a map
-// [group: (IP, ...), ...]
-func FetchNetbirdPeerGroups(apiURL, token string) (GroupPeers, error) {
-	req, err := http.NewRequest(http.MethodGet, apiURL+"/peers", nil)
+// makeAPIRequest creates and executes an HTTP request to the NetBird API
+func makeAPIRequest(apiURL, token, endpoint string) (*http.Response, error) {
+	req, err := http.NewRequest(http.MethodGet, apiURL+endpoint, nil)
 	if err != nil {
 		return nil, fmt.Errorf("creating request: %w", err)
 	}
@@ -33,23 +46,62 @@ func FetchNetbirdPeerGroups(apiURL, token string) (GroupPeers, error) {
 	if err != nil {
 		return nil, fmt.Errorf("executing request: %w", err)
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
 		return nil, fmt.Errorf("unexpected status %d: %s", resp.StatusCode, body)
 	}
 
-	var peers []peer
-	if err := json.NewDecoder(resp.Body).Decode(&peers); err != nil {
+	return resp, nil
+}
+
+// FetchNetbirdUsers calls the NetBird API users endpoint and returns a map
+// [userID: UserInfo]
+func FetchNetbirdUsers(apiURL, token string) (UserIDMap, error) {
+	resp, err := makeAPIRequest(apiURL, token, "/users")
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var users []UserInfo
+	if err := json.NewDecoder(resp.Body).Decode(&users); err != nil {
 		return nil, fmt.Errorf("decoding response: %w", err)
 	}
 
+	result := make(UserIDMap)
+	for _, u := range users {
+		result[u.ID] = u
+	}
+	return result, nil
+}
+
+// FetchNetbirdPeerGroups calls the NetBird API peers endpoint and returns a map
+// [group: (IP, ...), ...] and a map of IP to user ID
+func FetchNetbirdPeerGroups(apiURL, token string) (GroupPeers, IPUserMap, error) {
+	resp, err := makeAPIRequest(apiURL, token, "/peers")
+	if err != nil {
+		return nil, nil, err
+	}
+	defer resp.Body.Close()
+
+	var peers []peer
+	if err := json.NewDecoder(resp.Body).Decode(&peers); err != nil {
+		return nil, nil, fmt.Errorf("decoding response: %w", err)
+	}
+
 	result := make(GroupPeers)
+	ipUserMap := make(IPUserMap)
 	for _, p := range peers {
+		// Map IP to user ID
+		if p.UserID != "" {
+			ipUserMap[p.IP] = p.UserID
+		}
+
+		// Add IP to each group it belongs to
 		for _, g := range p.Groups {
 			result[g.Name] = append(result[g.Name], p.IP)
 		}
 	}
-	return result, nil
+	return result, ipUserMap, nil
 }


### PR DESCRIPTION
Hello,

I would like to propose this PR that adds the Remote-User and Remote-Email headers (configurable per instance) to automatically authenticate on some services (like frigate)

I've tested it on a Whoami and Frigate service of my home lab.

Let me know what you think :)